### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/Testbase.yml
+++ b/.github/workflows/Testbase.yml
@@ -18,9 +18,9 @@ jobs:
       QT_DEBUG_PLUGINS: 1
     steps:
       - name: Set up Python ${{ inputs.python }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.2.2
       - name: Install dependencies
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5.4.0
         with:
           python-version: ${{ inputs.python }}
       - name: Install package

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v4.2.2
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5.4.0
       with:
         python-version: '3.11'
     - name: Install dependencies

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.2.2](https://github.com/actions/checkout/releases/tag/v4.2.2)** on 2024-10-23T14:46:00Z
* **[actions/setup-python](https://github.com/actions/setup-python)** published a new release **[v5.4.0](https://github.com/actions/setup-python/releases/tag/v5.4.0)** on 2025-01-28T03:28:18Z
