### PR TITLE
Introduce the concept of grab signal override from extensions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ authors = [
     {name='Sebastien J. Weber', email='sebastien.weber@cnrs.fr'}
 ]
 dependencies = [
-    "pymodaq>5.0.0"
+    "pymodaq>=5.1.0"
 ]
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/src/pymodaq_plugins_datamixer/extensions/data_mixer.py
+++ b/src/pymodaq_plugins_datamixer/extensions/data_mixer.py
@@ -122,12 +122,13 @@ class DataMixer(CustomExt):
             self.dte_computed_signal.emit(dte_computed)
 
     def snap(self):
-        self.modules_manager.grab_data()
+        self.modules_manager.grab_data(check_do_override=False)
 
     def create_computed_detectors(self):
         try:
             self.dashboard.add_det_from_extension('DataMixer', 'DAQ0D', 'DataMixer', self)
             self.set_action_enabled('create_computed_detectors', False)
+            self.dashboard.override_det_from_extension(self.modules_manager.selected_detectors_name)
         except Exception as e:
             logger.exception(str(e))
             pass


### PR DESCRIPTION
This PR patch a problem with the fact that the output of the DataMixer can be added to the Dashboard to be used by other extensions such as the DAQ_Scan.

But, let's say I want to use the Mixer to plot some interesting live data out of a detector call *mydet*. I'll have in the Dahsbord a real detector: *mydet* and a "fake" one: *mymixeddata*. If I do a scan of *mymixeddata* as a function of one or more parameters, the grab signal of *mydet* will be fired once byt the datamixer. All is fine. **BUT** If I do a scan of *mymixeddata* and of *mydet* (to store the raw data) as a function of one or more parameters, the grab signal of *mydet* will be fired twice for each param. Once by the direct call of the daq_scan to *mydet* and once by  the datamixer. This is bad.

In pymodaq PR https://github.com/PyMoDAQ/PyMoDAQ/pull/588 introduces ways to handle this tohether with the commits in here